### PR TITLE
Unlock repository after GPG error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ Obnam NEWS
 
 This file summarizes changes between releases of Obnam.
 
+NOTE: Obnam has an **EXPERIMENTAL** repository format under
+development, called `green-albatross`. It is **NOT** meant for real
+use. It is likely to change in incompatible ways without warning. Do
+not use it unless you're willing to lose your backup.
+
 Version 1.13, released 2015-08-01
 ---------------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,12 @@ Bug fixes:
   Lars Wirzenius then changed things so that chunk files are only
   removed once references to the chunks have been committed.
 
+Improvements:
+
+* `obnam forget` now commits changes after each generation it has
+  removed. This means that if the operation is committed, less work is
+  lost. Suggested by Lukáš Poláček, re-implemented by Lars Wirzenius.
+
 Version 1.12, released 2015-07-08
 ---------------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,9 @@ Bug fixes:
   R43272X). `obnam forget` will now ignore such a missing chunk, since
   it would've deleted it anyway.
 
+  Lars Wirzenius then changed things so that chunk files are only
+  removed once references to the chunks have been committed.
+
 Version 1.12, released 2015-07-08
 ---------------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ Obnam NEWS
 
 This file summarizes changes between releases of Obnam.
 
-Version 1.13, released UNRELEASED
+Version 1.13, released 2015-08-01
 ---------------------------------
 
 Bug fixes:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-obnam (1.13-1) UNRELEASED; urgency=medium
+obnam (1.13-1) unstable; urgency=medium
 
   * New upstream version.
     * Fix "R43272X: Repository doesn't contain chunk" (Closes:
       #793792)
 
- -- Lars Wirzenius <liw@liw.fi>  Sat, 01 Aug 2015 18:32:22 +0300
+ -- Lars Wirzenius <liw@liw.fi>  Sat, 01 Aug 2015 19:24:46 +0300
 
 obnam (1.12-1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+obnam (1.13-1) UNRELEASED; urgency=medium
+
+  * New upstream version.
+    * Fix "R43272X: Repository doesn't contain chunk" (Closes:
+      #793792)
+
+ -- Lars Wirzenius <liw@liw.fi>  Sat, 01 Aug 2015 18:32:22 +0300
+
 obnam (1.12-1) unstable; urgency=medium
 
   * New upstream version.

--- a/obnamlib/__init__.py
+++ b/obnamlib/__init__.py
@@ -17,7 +17,7 @@
 import cliapp
 
 
-__version__ = '1.12'
+__version__ = '1.13'
 
 
 # Import _obnam if it is there. We need to be able to do things without

--- a/obnamlib/__init__.py
+++ b/obnamlib/__init__.py
@@ -89,7 +89,8 @@ from encryption import (generate_symmetric_key,
                         encrypt_with_keyring,
                         decrypt_with_secret_keys,
                         SymmetricKeyCache,
-                        EncryptionError)
+                        EncryptionError,
+                        GpgError)
 
 from hooks import (
     Hook, MissingFilterError, NoFilterTagError, FilterHook, HookManager)

--- a/obnamlib/delegator.py
+++ b/obnamlib/delegator.py
@@ -276,6 +276,9 @@ class RepositoryDelegator(obnamlib.RepositoryInterface):
     def flush_chunks(self):
         self._chunk_store.flush_chunks()
 
+    def remove_unused_chunks(self):
+        return self._chunk_store.remove_unused_chunks()
+
     def get_chunk_ids(self):
         return self._chunk_store.get_chunk_ids()
 

--- a/obnamlib/delegator.py
+++ b/obnamlib/delegator.py
@@ -111,6 +111,7 @@ class RepositoryDelegator(obnamlib.RepositoryInterface):
     def remove_client(self, client_name):
         self._require_we_got_client_list_lock()
         self._client_list.remove_client(client_name)
+        self._client_finder.remove_client(client_name)
 
     def rename_client(self, old_client_name, new_client_name):
         self._require_we_got_client_list_lock()
@@ -363,11 +364,11 @@ class ClientFinder(object):
         self._current_time = current_time
 
     def find_client(self, client_name):
-        if client_name not in self._client_list.get_client_names():
-            raise obnamlib.RepositoryClientDoesNotExist(
-                client_name=client_name)
-
         if client_name not in self._clients:
+            if client_name not in self._client_list.get_client_names():
+                raise obnamlib.RepositoryClientDoesNotExist(
+                    client_name=client_name)
+
             client = self._client_factory(client_name)
             client.set_fs(self._fs)
             dirname = self._client_list.get_client_dirname(client_name)
@@ -376,6 +377,10 @@ class ClientFinder(object):
             self._clients[client_name] = client
 
         return self._clients[client_name]
+
+    def remove_client(self, client_name):
+        if client_name in self._clients:
+            del self._clients[client_name]
 
 
 class GenerationId(object):

--- a/obnamlib/delegator.py
+++ b/obnamlib/delegator.py
@@ -94,7 +94,6 @@ class RepositoryDelegator(obnamlib.RepositoryInterface):
     def commit_client_list(self):
         self._require_we_got_client_list_lock()
         self._client_list.commit()
-        self.unlock_client_list()
 
     def got_client_list_lock(self):
         dirname = self._client_list.get_dirname()
@@ -163,7 +162,6 @@ class RepositoryDelegator(obnamlib.RepositoryInterface):
         self._require_got_client_lock(client_name)
         client = self._lookup_client(client_name)
         client.commit()
-        self.unlock_client(client_name)
 
     def got_client_lock(self, client_name):
         client = self._lookup_client(client_name)
@@ -310,7 +308,6 @@ class RepositoryDelegator(obnamlib.RepositoryInterface):
     def commit_chunk_indexes(self):
         self._require_we_got_chunk_indexes_lock()
         self._chunk_indexes.commit()
-        self.unlock_chunk_indexes()
 
     def got_chunk_indexes_lock(self):
         dirname = self._chunk_indexes.get_dirname()

--- a/obnamlib/fmt_6/repo_fmt_6.py
+++ b/obnamlib/fmt_6/repo_fmt_6.py
@@ -684,6 +684,9 @@ class RepositoryFormat6(obnamlib.RepositoryInterface):
     def flush_chunks(self):
         pass
 
+    def remove_unused_chunks(self):
+        pass
+
     def get_chunk_ids(self):
         # Note: This does not cover for in-tree chunk data. We cannot
         # realistically iterate over all per-client B-trees to find

--- a/obnamlib/fmt_ga/chunk_store.py
+++ b/obnamlib/fmt_ga/chunk_store.py
@@ -56,6 +56,10 @@ class GAChunkStore(object):
     def flush_chunks(self):
         self._blob_store.flush()
 
+    def remove_unused_chunks(self):
+        # FIXME: This is a no-op operation, for now.
+        pass
+
     def get_chunk_content(self, chunk_id):
         content = self._blob_store.get_blob(chunk_id)
         if content is None:

--- a/obnamlib/fmt_ga/client.py
+++ b/obnamlib/fmt_ga/client.py
@@ -205,11 +205,11 @@ class GAClient(object):
             return generation.get_key(key_name, default='')
 
     def _lookup_generation_by_gen_number(self, gen_number):
-        for generation in self._generations:
-            if generation.get_number() == gen_number:
-                return generation
-        raise obnamlib.RepositoryGenerationDoesNotExist(
-            gen_id=gen_number, client_name=self._client_name)
+        generation = self._generations.get_generation(gen_number)
+        if generation is None:
+            raise obnamlib.RepositoryGenerationDoesNotExist(
+                gen_id=gen_number, client_name=self._client_name)
+        return generation
 
     def set_generation_key(self, gen_number, key, value):
         self._load_data()
@@ -336,6 +336,7 @@ class GAGenerationList(object):
 
     def __init__(self):
         self._generations = []
+        self._by_number = {}
 
     def __len__(self):
         return len(self._generations)
@@ -344,14 +345,19 @@ class GAGenerationList(object):
         for gen in self._generations[:]:
             yield gen
 
+    def get_generation(self, gen_number):
+        return self._by_number.get(gen_number)
+
     def get_latest(self):
         return self._generations[-1]
 
     def append(self, gen):
         self._generations.append(gen)
+        self._by_number[gen.get_number()] = gen
 
     def set_generations(self, generations):
         self._generations = generations
+        self._by_number = dict((gen.get_number, gen) for gen in generations)
 
 
 class GAGeneration(object):

--- a/obnamlib/fmt_ga/client.py
+++ b/obnamlib/fmt_ga/client.py
@@ -264,16 +264,13 @@ class GAClient(object):
 
     def set_file_key(self, gen_number, filename, key, value):
         self._load_data()
-
         generation = self._lookup_generation_by_gen_number(gen_number)
         metadata = generation.get_file_metadata()
-        if not metadata.file_exists(filename):
+        if not metadata.set_file_key(filename, key, value):
             raise obnamlib.RepositoryFileDoesNotExistInGeneration(
                 client_name=self._client_name,
                 genspec=gen_number,
                 filename=filename)
-
-        metadata.set_file_key(filename, key, value)
 
     def get_file_chunk_ids(self, gen_number, filename):
         self._load_data()
@@ -514,10 +511,13 @@ class GAFileMetadata(object):
             self._added_files.set_file_key(filename, key, value)
             if key == obnamlib.REPO_FILE_MODE:
                 self._flush_added_file(filename)
+            return True
         else:
             dir_obj, basename = self._get_mutable_dir_obj(filename)
-            if dir_obj:
-                dir_obj.set_file_key(basename, key, value)
+            if not dir_obj:
+                return False
+            dir_obj.set_file_key(basename, key, value)
+        return True
 
     def _get_mutable_dir_obj(self, filename):
         dir_obj, dir_path, basename = self._get_dir_obj(filename)

--- a/obnamlib/fmt_ga/client.py
+++ b/obnamlib/fmt_ga/client.py
@@ -32,6 +32,12 @@ class GAClient(object):
         self._current_time = None
         self.clear()
 
+    def clear(self):
+        self._blob_store = None
+        self._client_keys = GAKeys()
+        self._generations = GAGenerationList()
+        self._data_is_loaded = False
+
     def set_current_time(self, current_time):
         self._current_time = current_time
 
@@ -43,12 +49,6 @@ class GAClient(object):
 
     def get_dirname(self):
         return self._dirname
-
-    def clear(self):
-        self._blob_store = None
-        self._client_keys = GAKeys()
-        self._generations = GAGenerationList()
-        self._data_is_loaded = False
 
     def commit(self):
         self._load_data()

--- a/obnamlib/fmt_ga/client.py
+++ b/obnamlib/fmt_ga/client.py
@@ -264,9 +264,15 @@ class GAClient(object):
 
     def set_file_key(self, gen_number, filename, key, value):
         self._load_data()
-        self._require_file_exists(gen_number, filename)
+
         generation = self._lookup_generation_by_gen_number(gen_number)
         metadata = generation.get_file_metadata()
+        if not metadata.file_exists(filename):
+            raise obnamlib.RepositoryFileDoesNotExistInGeneration(
+                client_name=self._client_name,
+                genspec=gen_number,
+                filename=filename)
+
         metadata.set_file_key(filename, key, value)
 
     def get_file_chunk_ids(self, gen_number, filename):

--- a/obnamlib/fmt_ga/tree.py
+++ b/obnamlib/fmt_ga/tree.py
@@ -53,10 +53,7 @@ class GATree(object):
 
     def get_directory(self, pathname):
         if pathname in self._cache:
-            tracing.trace('cache hit: pathname=%r', pathname)
             return self._cache.get(pathname)
-
-        tracing.trace('cache miss: pathname=%r', pathname)
 
         if self._root_dir_id is None:
             return None

--- a/obnamlib/fmt_ga/tree.py
+++ b/obnamlib/fmt_ga/tree.py
@@ -52,8 +52,9 @@ class GATree(object):
         return self._root_dir_id
 
     def get_directory(self, pathname):
-        if pathname in self._cache:
-            return self._cache.get(pathname)
+        dir_obj = self._cache.get(pathname)
+        if dir_obj is not None:
+            return dir_obj
 
         if self._root_dir_id is None:
             return None

--- a/obnamlib/plugins/backup_plugin.py
+++ b/obnamlib/plugins/backup_plugin.py
@@ -482,7 +482,12 @@ class BackupPlugin(obnamlib.ObnamPlugin):
         self.chunkid_token_map.clear()
 
     def add_client(self, client_name):
-        self.repo.lock_client_list()
+        try:
+            self.repo.lock_client_list()
+        except obnamlib.GpgError:
+            self.repo.unlock_client_list()
+            raise
+
         if client_name not in self.repo.get_client_names():
             tracing.trace('adding new client %s' % client_name)
             tracing.trace('client list before adding: %s' %

--- a/obnamlib/plugins/backup_plugin.py
+++ b/obnamlib/plugins/backup_plugin.py
@@ -647,13 +647,17 @@ class BackupPlugin(obnamlib.ObnamPlugin):
         self.progress.what('making checkpoint')
         if not self.pretend:
             self.checkpoint_manager.add_checkpoint(self.new_generation)
+
             self.progress.what('making checkpoint: backing up parents')
             self.backup_parents('.')
+
             self.progress.what('making checkpoint: locking shared B-trees')
             self.repo.lock_chunk_indexes()
+
             self.progress.what(
                 'making checkpoint: adding chunks to shared B-trees')
             self.add_chunks_to_shared()
+
             self.progress.what(
                 'making checkpoint: committing per-client B-tree')
             self.repo.set_generation_key(
@@ -662,18 +666,22 @@ class BackupPlugin(obnamlib.ObnamPlugin):
             self.repo.flush_chunks()
             self.repo.commit_client(self.client_name)
             self.repo.unlock_client(self.client_name)
+
             self.progress.what('making checkpoint: committing shared B-trees')
             self.repo.commit_chunk_indexes()
             self.repo.unlock_chunk_indexes()
             self.last_checkpoint = self.repo.get_fs().bytes_written
+
             self.progress.what('making checkpoint: re-opening repository')
             self.repo = self.app.get_repository_object(
                 repofs=self.repo.get_fs())
+
             self.progress.what('making checkpoint: starting a new generation')
             self.repo.lock_client(self.client_name)
             self.new_generation = self.repo.create_generation(
                 self.client_name)
             self.app.dump_memory_profile('at end of checkpoint')
+
             self.progress.what('making checkpoint: continuing backup')
 
     def find_files(self, root):

--- a/obnamlib/plugins/backup_plugin.py
+++ b/obnamlib/plugins/backup_plugin.py
@@ -422,11 +422,13 @@ class BackupPlugin(obnamlib.ObnamPlugin):
             self.repo.remove_generation(gen)
 
         self.progress.what(prefix + ': committing client')
-        self.repo.flush_chunks()
         self.repo.commit_client(self.client_name)
 
         self.progress.what(prefix + ': commiting shared B-trees')
         self.repo.commit_chunk_indexes()
+
+        self.progress.what(prefix + ': removing unused chunks')
+        self.repo.remove_unused_chunks()
 
         self.repo.unlock_everything()
 

--- a/obnamlib/plugins/encryption_plugin.py
+++ b/obnamlib/plugins/encryption_plugin.py
@@ -287,3 +287,4 @@ class EncryptionPlugin(obnamlib.ObnamPlugin):
             logging.info('removing client %s' % client_name)
             repo.remove_client(client_name)
         repo.commit_client_list()
+        repo.unlock_client_list()

--- a/obnamlib/plugins/forget_plugin.py
+++ b/obnamlib/plugins/forget_plugin.py
@@ -85,8 +85,9 @@ class ForgetPlugin(obnamlib.ObnamPlugin):
         self.remove_generations(removeids)
 
         # Commit or unlock everything.
-        self.repo.flush_chunks()
         self.repo.commit_client(client_name)
+        self.repo.commit_chunk_indexes()
+        self.repo.remove_unused_chunks()
         self.repo.unlock_everything()
         self.app.dump_memory_profile('after committing')
 

--- a/obnamlib/plugins/forget_plugin.py
+++ b/obnamlib/plugins/forget_plugin.py
@@ -87,8 +87,8 @@ class ForgetPlugin(obnamlib.ObnamPlugin):
         # Commit or unlock everything.
         self.repo.commit_client(client_name)
         self.repo.commit_chunk_indexes()
-        self.repo.remove_unused_chunks()
         self.repo.unlock_everything()
+        self.repo.remove_unused_chunks()
         self.app.dump_memory_profile('after committing')
 
         self.repo.close()

--- a/obnamlib/repo_interface.py
+++ b/obnamlib/repo_interface.py
@@ -740,6 +740,15 @@ class RepositoryInterface(object):
         '''Write any pending new chunks to repository.'''
         raise NotImplementedError()
 
+    def remove_unused_chunk(self):
+        '''Remove chunks that are no longer used by any client.
+
+        The caller MUST commit any changes to clients or chunk indexes
+        before calling this method.
+
+        '''
+        raise NotImplementedError()
+
     def lock_chunk_indexes(self):
         '''Locks chunk indexes for updates.'''
         raise NotImplementedError()

--- a/obnamlib/repo_interface.py
+++ b/obnamlib/repo_interface.py
@@ -737,7 +737,7 @@ class RepositoryInterface(object):
         raise NotImplementedError()
 
     def flush_chunks(self):
-        '''Flush any pending chunks.'''
+        '''Write any pending new chunks to repository.'''
         raise NotImplementedError()
 
     def lock_chunk_indexes(self):

--- a/setup.py
+++ b/setup.py
@@ -294,7 +294,7 @@ class Check(Command):
 
 
 setup(name='obnam',
-      version='1.12',
+      version='1.13',
       description='Backup software',
       author='Lars Wirzenius',
       author_email='liw@liw.fi',


### PR DESCRIPTION
When user inputs a wrong key or clicks cancel on the pinentry dialog, the backup/forget operation fails but the repository remains locked. The problem is that lock is acquired before GPG is started.